### PR TITLE
Added Base Path to Build Configuration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "timezone-webapp-frontend",
   "private": true,
   "version": "0.0.0",
-  "homepage": "",
+  "homepage": "/",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -16,5 +16,5 @@ export default defineConfig({
       },
     },
   },
-  base: "",
+  base: "/",
 })


### PR DESCRIPTION
This should fix a bug where reloading on the timezone page causes the page not to load assets correctly.